### PR TITLE
Fixed resizing algorithms

### DIFF
--- a/src/IPub/Images/Application/Presenter.php
+++ b/src/IPub/Images/Application/Presenter.php
@@ -186,7 +186,7 @@ class ImagesPresenter extends Nette\Object implements Application\IPresenter
 					break;
 
 				default:
-					$algorithm = NULL;
+					$algorithm = ctype_digit($algorithm) ? (int) $algorithm : NULL;
 			}
 
 		} else {


### PR DESCRIPTION
The `'shrink_only'` constant in Latte didn't work for me because the Presenter got `"1"` as algorithm parameter. Of course it was string, not int so it didn't work.

You might want to fix this elsewhere though.
