### PR TITLE
Fixes #4

### DIFF
--- a/src/IPub/Images/Application/Presenter.php
+++ b/src/IPub/Images/Application/Presenter.php
@@ -226,7 +226,8 @@ class ImagesPresenter extends Nette\Object implements Application\IPresenter
 
 		if ($image instanceof Utils\Image) {
 			// Process image resizing etc.
-			$image->resize($width, $height, $algorithm);
+			if($width || $height)
+				$image->resize($width, $height, $algorithm);
 			// Save into new place
 			$success = $image->save($destination, 90);
 

--- a/src/IPub/Images/Application/Presenter.php
+++ b/src/IPub/Images/Application/Presenter.php
@@ -226,8 +226,9 @@ class ImagesPresenter extends Nette\Object implements Application\IPresenter
 
 		if ($image instanceof Utils\Image) {
 			// Process image resizing etc.
-			if($width || $height)
+			if($width || $height){
 				$image->resize($width, $height, $algorithm);
+			}
 			// Save into new place
 			$success = $image->save($destination, 90);
 


### PR DESCRIPTION
If the size is "original" so the $width and $height are NULL, because:

if ($size == 'original') {
    $width = $height = NULL;

But in method "Nette\Utils\Image::calculateSize" at least width or height must be specified. So If we want to get original image, there is nothing fo resizing.
